### PR TITLE
Updates Node to version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,5 +72,5 @@ inputs:
     description: 'Github API token'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
All GitHub Actions will run on [Node16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) instead of Node12 by Summer 2023. This PR is to resolve the current warnings when using it in a workflow.