### PR TITLE
Upgrade to Node20 to avoid problems with Node16 sunsetting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,5 +72,5 @@ inputs:
     description: 'Github API token'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Prepares for Node 16 to 20 transition expected in Spring 2024: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/